### PR TITLE
Make VLANMembersView only show distinct interfaces

### DIFF
--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -894,7 +894,7 @@ class VLANMembersView(View):
     def get(self, request, pk):
 
         vlan = get_object_or_404(VLAN.objects.all(), pk=pk)
-        members = vlan.get_members().select_related('device', 'virtual_machine')
+        members = vlan.get_members().select_related('device', 'virtual_machine').distinct()
 
         members_table = tables.VLANMemberTable(members)
 


### PR DESCRIPTION
This prevents duplication of interfaces in the VLAN Members Table.

<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes:

<!--
    Please include a summary of the proposed changes below.
-->
I believe the current query ends up selecting some interfaces multiple times, and because the query has a LIMIT of the number of VLAN members it will stop before all interfaces are selected. By making the request use distinct, a interface will not show up multiple times in the returned data.